### PR TITLE
Fix floor collision detection

### DIFF
--- a/Assets/Assets/Scripts/FloorCollision.cs
+++ b/Assets/Assets/Scripts/FloorCollision.cs
@@ -27,7 +27,11 @@ public class FloorCollision : MonoBehaviour
                 continue;
             }
 
-            float objectBottomY = obj.transform.position.y + collider.bounds.min.y;
+            // collider.bounds.min.y already gives the world position of the bottom
+            // of the collider, so adding obj.transform.position.y results in an
+            // incorrect value. Use bounds.min.y directly to check against the
+            // floor position.
+            float objectBottomY = collider.bounds.min.y;
 
             if (objectBottomY >= floorY)
             {


### PR DESCRIPTION
## Summary
- correct floor collision detection by using `collider.bounds.min.y` instead of double-counting object position
- add missing newline at end of `FloorCollision.cs`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68480e85b89c8323bba3f714a5abf346