### PR TITLE
Implement undo functionality for cat sort mode

### DIFF
--- a/Assets/Assets/Scripts/CatSortMode.cs
+++ b/Assets/Assets/Scripts/CatSortMode.cs
@@ -9,7 +9,15 @@ public class CatSortMode : MonoBehaviour
 {
     [SerializeField] private GameObject shelfPrefab;
     [SerializeField] private GameObject catPrefab;
-    [SerializeField] private Sprite[] catSprites; // Массив спрайтов: [type_0, type_0_jump, type_1, type_1_jump, ...]
+    private struct Move
+    {
+        public Shelf source;
+        public Shelf target;
+        public List<Cat> cats;
+        public List<int> sourceIndices;
+    }
+    private Stack<Move> moveStack = new Stack<Move>();
+    [SerializeField] private Sprite[] catSprites; // ГЊГ Г±Г±ГЁГў Г±ГЇГ°Г Г©ГІГ®Гў: [type_0, type_0_jump, type_1, type_1_jump, ...]
     [SerializeField] private GameObject levelCompletePanel;
     [SerializeField] private Button nextLevelButton;
     [SerializeField] private Button exitButton;
@@ -19,7 +27,7 @@ public class CatSortMode : MonoBehaviour
     [System.Serializable]
     public class Cat
     {
-        public int type; // 0 to 11 для 12 типов котов
+        public int type; // 0 to 11 Г¤Г«Гї 12 ГІГЁГЇГ®Гў ГЄГ®ГІГ®Гў
         public bool isSelected;
         public Transform transform;
         public SpriteRenderer spriteRenderer;
@@ -66,8 +74,8 @@ public class CatSortMode : MonoBehaviour
 
     private void InitializeShelves()
     {
-        int leftShelves = 2; // 2 полки слева
-        int rightShelves = 1; // 1 полка справа
+        int leftShelves = 2; // 2 ГЇГ®Г«ГЄГЁ Г±Г«ГҐГўГ 
+        int rightShelves = 1; // 1 ГЇГ®Г«ГЄГ  Г±ГЇГ°Г ГўГ 
 
         float screenWidth = Camera.main.orthographicSize * 2 * Camera.main.aspect;
         float shelfHeight = 1f;
@@ -154,6 +162,14 @@ public class CatSortMode : MonoBehaviour
             }
         }
     }
+    private void UpdateShelfPositions(Shelf shelf)
+    {
+        for (int i = 0; i < shelf.cats.Count; i++)
+        {
+            shelf.cats[i].transform.position = shelf.shelfTransform.position + Vector3.right * (i - shelf.cats.Count / 2f) * 0.5f;
+        }
+    }
+
 
     private void MoveSelectedCats(Shelf targetShelf)
     {
@@ -171,6 +187,7 @@ public class CatSortMode : MonoBehaviour
             return;
         }
 
+        List<int> indices = selectedCats.Select(c => sourceShelf.cats.IndexOf(c)).ToList();
         StartCoroutine(MoveCatsAnimation(sourceShelf, targetShelf, selectedCats));
         foreach (var cat in selectedCats)
         {
@@ -178,6 +195,9 @@ public class CatSortMode : MonoBehaviour
             targetShelf.cats.Add(cat);
             cat.isSelected = false;
         }
+        moveStack.Push(new Move { source = sourceShelf, target = targetShelf, cats = new List<Cat>(selectedCats), sourceIndices = indices });
+        UpdateShelfPositions(sourceShelf);
+        UpdateShelfPositions(targetShelf);
         UpdateVisualSelection();
         CheckLevelCompletion();
     }
@@ -189,7 +209,9 @@ public class CatSortMode : MonoBehaviour
         float duration = 0.5f;
         float elapsed = 0f;
 
-        // Переключение на спрайт прыжка
+        UpdateShelfPositions(sourceShelf);
+        UpdateShelfPositions(targetShelf);
+        // ГЏГҐГ°ГҐГЄГ«ГѕГ·ГҐГ­ГЁГҐ Г­Г  Г±ГЇГ°Г Г©ГІ ГЇГ°Г»Г¦ГЄГ 
         foreach (var cat in cats)
         {
             cat.spriteRenderer.sprite = catSprites[cat.type * 2 + 1]; // type_0_jump, type_1_jump, etc.
@@ -199,7 +221,7 @@ public class CatSortMode : MonoBehaviour
         {
             elapsed += Time.deltaTime;
             float t = elapsed / duration;
-            float height = Mathf.Sin(t * Mathf.PI) * 1f; // Параболическая траектория прыжка
+            float height = Mathf.Sin(t * Mathf.PI) * 1f; // ГЏГ Г°Г ГЎГ®Г«ГЁГ·ГҐГ±ГЄГ Гї ГІГ°Г ГҐГЄГІГ®Г°ГЁГї ГЇГ°Г»Г¦ГЄГ 
             Vector3 midPos = Vector3.Lerp(startPos, endPos, t) + Vector3.up * height;
             foreach (var cat in cats)
             {
@@ -208,7 +230,7 @@ public class CatSortMode : MonoBehaviour
             yield return null;
         }
 
-        // Возвращение к обычному спрайту
+        // Г‚Г®Г§ГўГ°Г Г№ГҐГ­ГЁГҐ ГЄ Г®ГЎГ»Г·Г­Г®Г¬Гі Г±ГЇГ°Г Г©ГІГі
         for (int i = 0; i < cats.Count; i++)
         {
             cats[i].transform.position = targetShelf.shelfTransform.position + Vector3.right * (i - cats.Count / 2) * 0.5f;
@@ -234,29 +256,29 @@ public class CatSortMode : MonoBehaviour
             shelf.cats.Clear();
         }
 
-        // Для первого уровня: гарантируем 4 кота
-        int levelIndex = PlayerPrefs.GetInt("CatSortLevel", 0); // Получаем текущий уровень (по умолчанию 0)
-        if (levelIndex == 0) // Первый уровень (учебный)
+        // Г„Г«Гї ГЇГҐГ°ГўГ®ГЈГ® ГіГ°Г®ГўГ­Гї: ГЈГ Г°Г Г­ГІГЁГ°ГіГҐГ¬ 4 ГЄГ®ГІГ 
+        int levelIndex = PlayerPrefs.GetInt("CatSortLevel", 0); // ГЏГ®Г«ГіГ·Г ГҐГ¬ ГІГҐГЄГіГ№ГЁГ© ГіГ°Г®ГўГҐГ­Гј (ГЇГ® ГіГ¬Г®Г«Г·Г Г­ГЁГѕ 0)
+        if (levelIndex == 0) // ГЏГҐГ°ГўГ»Г© ГіГ°Г®ГўГҐГ­Гј (ГіГ·ГҐГЎГ­Г»Г©)
         {
-            Shelf targetShelf = shelves[0]; // Используем первую полку
+            Shelf targetShelf = shelves[0]; // Г€Г±ГЇГ®Г«ГјГ§ГіГҐГ¬ ГЇГҐГ°ГўГіГѕ ГЇГ®Г«ГЄГі
             for (int i = 0; i < 4; i++)
             {
                 GameObject catObj = Instantiate(catPrefab, targetShelf.shelfTransform.position + Vector3.right * (i - 1.5f) * 0.5f, Quaternion.identity);
                 Cat cat = new Cat
                 {
-                    type = 0, // Один тип кота для простоты
+                    type = 0, // ГЋГ¤ГЁГ­ ГІГЁГЇ ГЄГ®ГІГ  Г¤Г«Гї ГЇГ°Г®Г±ГІГ®ГІГ»
                     transform = catObj.transform,
                     spriteRenderer = catObj.GetComponent<SpriteRenderer>()
                 };
-                cat.spriteRenderer.sprite = catSprites[cat.type * 2]; // Установка начального спрайта
+                cat.spriteRenderer.sprite = catSprites[cat.type * 2]; // Г“Г±ГІГ Г­Г®ГўГЄГ  Г­Г Г·Г Г«ГјГ­Г®ГЈГ® Г±ГЇГ°Г Г©ГІГ 
                 targetShelf.cats.Add(cat);
             }
         }
-        else // Для последующих уровней: случайная генерация
+        else // Г„Г«Гї ГЇГ®Г±Г«ГҐГ¤ГіГѕГ№ГЁГµ ГіГ°Г®ГўГ­ГҐГ©: Г±Г«ГіГ·Г Г©Г­Г Гї ГЈГҐГ­ГҐГ°Г Г¶ГЁГї
         {
             foreach (var shelf in shelves)
             {
-                int catCount = Random.Range(1, 5); // От 1 до 4 котов на полку
+                int catCount = Random.Range(1, 5); // ГЋГІ 1 Г¤Г® 4 ГЄГ®ГІГ®Гў Г­Г  ГЇГ®Г«ГЄГі
                 for (int i = 0; i < catCount; i++)
                 {
                     GameObject catObj = Instantiate(catPrefab, shelf.shelfTransform.position + Vector3.right * (i - catCount / 2) * 0.5f, Quaternion.identity);
@@ -266,7 +288,7 @@ public class CatSortMode : MonoBehaviour
                         transform = catObj.transform,
                         spriteRenderer = catObj.GetComponent<SpriteRenderer>()
                     };
-                    cat.spriteRenderer.sprite = catSprites[cat.type * 2]; // Установка начального спрайта
+                    cat.spriteRenderer.sprite = catSprites[cat.type * 2]; // Г“Г±ГІГ Г­Г®ГўГЄГ  Г­Г Г·Г Г«ГјГ­Г®ГЈГ® Г±ГЇГ°Г Г©ГІГ 
                     shelf.cats.Add(cat);
                 }
             }
@@ -288,7 +310,7 @@ public class CatSortMode : MonoBehaviour
 
         if (isComplete)
         {
-            ShowLevelCompletePanel(4 * shelves.Count); // Простая логика счета (4 кота на полку * количество полок)
+            ShowLevelCompletePanel(4 * shelves.Count); // ГЏГ°Г®Г±ГІГ Гї Г«Г®ГЈГЁГЄГ  Г±Г·ГҐГІГ  (4 ГЄГ®ГІГ  Г­Г  ГЇГ®Г«ГЄГі * ГЄГ®Г«ГЁГ·ГҐГ±ГІГўГ® ГЇГ®Г«Г®ГЄ)
         }
     }
 
@@ -317,7 +339,28 @@ public class CatSortMode : MonoBehaviour
 
         if (GameModeManager.Instance != null)
         {
-            GameModeManager.Instance.ShowLevelCompletePanel(rawScore, 0, 0); // Передаем 0 для оптимальных и фактических ходов как заглушки
+    public void UndoMove()
+    {
+        if (moveStack.Count == 0) return;
+        Move move = moveStack.Pop();
+        foreach (var cat in move.cats)
+        {
+            move.target.cats.Remove(cat);
+        }
+        for (int i = 0; i < move.cats.Count; i++)
+        {
+            Cat cat = move.cats[i];
+            int index = move.sourceIndices[i];
+            if (index >= move.source.cats.Count) move.source.cats.Add(cat);
+            else move.source.cats.Insert(index, cat);
+            cat.isSelected = false;
+        }
+        UpdateShelfPositions(move.source);
+        UpdateShelfPositions(move.target);
+        UpdateVisualSelection();
+    }
+
+            GameModeManager.Instance.ShowLevelCompletePanel(rawScore, 0, 0); // ГЏГҐГ°ГҐГ¤Г ГҐГ¬ 0 Г¤Г«Гї Г®ГЇГІГЁГ¬Г Г«ГјГ­Г»Гµ ГЁ ГґГ ГЄГІГЁГ·ГҐГ±ГЄГЁГµ ГµГ®Г¤Г®Гў ГЄГ ГЄ Г§Г ГЈГ«ГіГёГЄГЁ
         }
     }
 

--- a/Assets/Assets/Scripts/GameModeManager.cs
+++ b/Assets/Assets/Scripts/GameModeManager.cs
@@ -61,6 +61,7 @@ public class GameModeManager : MonoBehaviour
     public CatSortMode catSortMode;
     public Button catSortStartButton;
 
+    public Button undoButton;
     [Header("Level Complete UI")]
     public GameObject levelCompletePanel;
     public TextMeshProUGUI levelCompleteScoreText;
@@ -196,6 +197,7 @@ public class GameModeManager : MonoBehaviour
         if (catSortPanel == null) Debug.LogError("CatSortPanel not assigned!");
         if (catSortStartButton == null) Debug.LogError("CatSortStartButton not assigned!");
 
+        if (undoButton == null) Debug.LogError("UndoButton not assigned!");
         ConfigureButtons();
 
         survivalPanel?.SetActive(false);
@@ -328,6 +330,11 @@ public class GameModeManager : MonoBehaviour
         if (catSortStartButton != null)
         {
             catSortStartButton.onClick.AddListener(StartCatSortMode);
+        }
+        if (undoButton != null)
+        {
+            undoButton.onClick.RemoveAllListeners();
+            undoButton.onClick.AddListener(() => catSortMode?.UndoMove());
         }
         if (closeSettingsButton != null)
         {


### PR DESCRIPTION
## Summary
- add `Move` struct and stack in `CatSortMode`
- track moves when transferring cats and update shelf positions
- provide `UndoMove` method
- expose undo button in `GameModeManager` and wire it up

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68481848f56083239be811c939bf40c2