### PR TITLE
Fix shelf count variables

### DIFF
--- a/Assets/Assets/Scripts/CatSortMode.cs
+++ b/Assets/Assets/Scripts/CatSortMode.cs
@@ -13,6 +13,8 @@ public class CatSortMode : MonoBehaviour
     [SerializeField] private GameObject levelCompletePanel;
     [SerializeField] private Button nextLevelButton;
     [SerializeField] private Button exitButton;
+    [SerializeField] private int leftShelves = 2;
+    [SerializeField] private int rightShelves = 2;
     private List<Shelf> shelves = new List<Shelf>();
     private AudioVibrationManager audioVibrationManager;
 


### PR DESCRIPTION
## Summary
- add `leftShelves` and `rightShelves` fields to CatSortMode

## Testing
- `grep -n leftShelves Assets/Assets/Scripts/CatSortMode.cs`
- `grep -n rightShelves Assets/Assets/Scripts/CatSortMode.cs`


------
https://chatgpt.com/codex/tasks/task_e_684824ecc5c08323a6d9da7707f307a9