### PR TITLE
Stop timers when Cat Sort finishes

### DIFF
--- a/Assets/Assets/Scripts/CatSortMode.cs
+++ b/Assets/Assets/Scripts/CatSortMode.cs
@@ -341,6 +341,18 @@ public class CatSortMode : MonoBehaviour
         return true;
     }
 
+    private void CheckAllShelvesEmpty()
+    {
+        if (AreAllShelvesEmpty())
+        {
+            if (GameModeManager.Instance != null)
+            {
+                GameModeManager.Instance.SetGameActive(false);
+            }
+            ShowLevelCompletePanel(shelves.Count * 4);
+        }
+    }
+
     private IEnumerator AssembleShelf(Shelf shelf)
     {
         float upDuration = 0.2f;
@@ -376,10 +388,7 @@ public class CatSortMode : MonoBehaviour
         }
         shelf.cats.Clear();
 
-        if (AreAllShelvesEmpty())
-        {
-            ShowLevelCompletePanel(shelves.Count * 4);
-        }
+        CheckAllShelvesEmpty();
     }
 
     public void GenerateLevel()

--- a/Assets/Assets/Scripts/GameModeManager.cs
+++ b/Assets/Assets/Scripts/GameModeManager.cs
@@ -134,6 +134,11 @@ public class GameModeManager : MonoBehaviour
 
     private bool isGameActive = false;
 
+    public void SetGameActive(bool active)
+    {
+        isGameActive = active;
+    }
+
     private int pendingStartScore;
     private int pendingFinalScore;
     private int pendingStar2Threshold;


### PR DESCRIPTION
## Summary
- expose `SetGameActive` in `GameModeManager`
- call the new method from Cat Sort when all shelves are cleared

## Testing
- `pytest -q`
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68494112f714832388183099000b4c3c