### PR TITLE
Add level definitions to CatSortMode

### DIFF
--- a/Assets/Assets/Scripts/GameModeManager.cs
+++ b/Assets/Assets/Scripts/GameModeManager.cs
@@ -965,8 +965,8 @@ public class GameModeManager : MonoBehaviour
         }
         else if (currentMode == GameMode.CatSort && catSortMode != null)
         {
-            int newLevelIndex = PlayerPrefs.GetInt("CatSortLevel", 0) + 1;
-            PlayerPrefs.SetInt("CatSortLevel", newLevelIndex);
+            int newLevelIndex = PlayerPrefs.GetInt("CatSortModeLevel", 0) + 1;
+            PlayerPrefs.SetInt("CatSortModeLevel", newLevelIndex);
             PlayerPrefs.Save();
             Debug.Log($"ShowLevelCompletePanel: CatSort progress saved. Next level index set to {newLevelIndex}");
         }


### PR DESCRIPTION
## Summary
- introduce `LevelDefinition` for CatSortMode
- spawn shelves and cats from level definitions
- save CatSort progress using `CatSortModeLevel`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684932048a3c832381f3353a07653738