### PR TITLE
Fix CatSort level complete panel display

### DIFF
--- a/Assets/Assets/Scripts/CatSortMode.cs
+++ b/Assets/Assets/Scripts/CatSortMode.cs
@@ -345,10 +345,6 @@ public class CatSortMode : MonoBehaviour
     {
         if (AreAllShelvesEmpty())
         {
-            if (GameModeManager.Instance != null)
-            {
-                GameModeManager.Instance.SetGameActive(false);
-            }
             ShowLevelCompletePanel(shelves.Count * 4);
         }
     }


### PR DESCRIPTION
## Summary
- remove game active flag reset from `CheckAllShelvesEmpty` so `GameModeManager` remains active
- call the level complete panel directly when shelves are empty

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68495726b6488323b483094270488f39